### PR TITLE
Work with select2 v4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,19 +21,15 @@ const PATH = {
         dependencies: {
             css: [
                 'node_modules/bootstrap/dist/css/bootstrap.css',
-                'node_modules/select2/select2.css'
+                'node_modules/select2/dist/css/select2.css'
             ],
             js: [
                 'node_modules/jquery/dist/jquery.js',
                 'node_modules/jquery-ui-dist/jquery-ui.js',
                 'node_modules/bootstrap/dist/js/bootstrap.js',
-                'node_modules/select2/select2.js',
+                'node_modules/select2/dist/js/select2.js',
                 'node_modules/fabric/dist/fabric.js',
                 'node_modules/clipboard/dist/clipboard.js'
-            ],
-            img: [
-                'node_modules/select2/*.png',
-                'node_modules/select2/*.gif'
             ]
         },
     },
@@ -56,7 +52,7 @@ const PATH = {
     }
 };
 
-let config = {source: {css: '', js: '', img: '', html: '', json: ''}, destination: {css: '', js: '', root: ''}};
+let config = {source: {css: '', js: '', html: '', json: ''}, destination: {css: '', js: '', root: ''}};
 
 function concat_minify_css(name, source, destination) {
     return gulp.src(source, { sourcemaps: true })
@@ -79,7 +75,6 @@ function concat_uglify_js(name, source, destination) {
 function config_env(env) {
     config.source.css = PATH.source.dependencies.css.concat(PATH.source.app.css);
     config.source.js = PATH.source.dependencies.js.concat(PATH.source.app.js);
-    config.source.img = PATH.source.dependencies.img;
     config.source.html = PATH.source.app.html;
     config.destination.css = PATH.destination[env].css;
     config.destination.js = PATH.destination[env].js;
@@ -121,12 +116,6 @@ gulp.task('copy.src', () => {
     const js = gulp.src(config.source.js)
         .pipe(gulp.dest(config.destination.js));
     return mergeStream(css, js);
-});
-
-// Copy images of Select2 (v3.5.1) dependency to 'dist/prod/css'
-gulp.task('copy.img', () => {
-    return gulp.src(config.source.img)
-        .pipe(gulp.dest(config.destination.css));
 });
 
 gulp.task('inject.prod', () => {
@@ -176,11 +165,11 @@ gulp.task('server.prod', async () => {
 
 gulp.task('build.dist', gulp.series('config.pack', 'clean', 'css', 'js'));
 
-gulp.task('build.dev', gulp.series('config.dev', 'clean', 'copy.src', 'copy.img', 'inject.dev'));
+gulp.task('build.dev', gulp.series('config.dev', 'clean', 'copy.src', 'inject.dev'));
 
 gulp.task('serve.dev', gulp.series('build.dev', 'server.dev'));
 
-gulp.task('build.prod', gulp.series('config.prod', 'clean', 'css', 'js', 'copy.img', 'inject.prod'));
+gulp.task('build.prod', gulp.series('config.prod', 'clean', 'css', 'js', 'inject.prod'));
 
 gulp.task('serve.prod', gulp.series('build.prod', 'server.prod'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plate-map",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -52,6 +52,11 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "almond": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/almond/-/almond-0.3.3.tgz",
+      "integrity": "sha1-oOfJWsdiTWQXtElLHmi/9pMWiiA="
     },
     "ansi-colors": {
       "version": "1.1.0",
@@ -3708,6 +3713,11 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
+    "jquery-mousewheel": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
+      "integrity": "sha1-BvAzXxbjU6aV5yBr9QUDy1I6buU="
+    },
     "jquery-ui-dist": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz",
@@ -5322,9 +5332,13 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "select2": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
-      "integrity": "sha1-8oGUibvGX9bTKL5yu+K5XdfofP4="
+      "version": "4.0.6-rc.1",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.6-rc.1.tgz",
+      "integrity": "sha1-qmwwOKfw8ukf+t448KIcFeGBMnY=",
+      "requires": {
+        "almond": "~0.3.1",
+        "jquery-mousewheel": "~3.1.13"
+      }
     },
     "semver": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jquery": "^3.3.1",
     "jquery-ui-dist": "^1.12.1",
     "popper.js": "^1.14.7",
-    "select2": "^3.5.1"
+    "select2": "^4.0.6-rc.1"
   },
   "devDependencies": {
     "browser-sync": "^2.26.3",

--- a/src/js/add-tab-data.js
+++ b/src/js/add-tab-data.js
@@ -226,11 +226,9 @@ var plateLayOutWidget = plateLayOutWidget || {};
         });
 
         field.getValue = function() {
-          var v = field.input.select2('data');
+          var v = field.input.val();
           if (v.length) {
-            return v.map(function(i) {
-              return i.id;
-            });
+            return v;
           }
           return null;
         };

--- a/src/js/create-field.js
+++ b/src/js/create-field.js
@@ -179,6 +179,12 @@ var plateLayOutWidget = plateLayOutWidget || {};
           field.onChange();
         });
 
+
+        input.on('select2:unselect', function (evt) {
+            // Prevent select2 v4.0.6rc1 opening dropdown on unselect
+            input.one('select2:opening', function(e) { e.preventDefault(); });
+        });
+
         field.input = input;
       },
 
@@ -286,6 +292,8 @@ var plateLayOutWidget = plateLayOutWidget || {};
 
         input.on("select2:unselect", function (e) {
           field.multiOnChange(null, e.params.data);
+          // Prevent select2 v4.0.6rc1 opening dropdown on unselect
+          input.one('select2:opening', function(e) { e.preventDefault(); });
         });
 
         field.input = input;
@@ -670,6 +678,12 @@ var plateLayOutWidget = plateLayOutWidget || {};
 
         input.on("change", function(e) {
           field.onChange();
+        });
+
+
+        input.on('select2:unselect', function (evt) {
+          // Prevent select2 v4.0.6rc1 opening dropdown on unselect
+          input.one('select2:opening', function(e) { e.preventDefault(); });
         });
 
         field.input = input;


### PR DESCRIPTION
Use select2 v4. Better supported by modern javascript. 

**NOTED ISSUES**

As of Select2 v4.0.6rc1 (and previous v4 versions) there is odd behavior around clicking the "unselect" x button. Instead of just removing the item in a multiselect, or clearing the selection of a select, it also opens the dropdown. This behavior was not present in 3.5.3, and has been documented since 2015 (https://github.com/select2/select2/issues/3320). Despite being raised many times along with some pull requests, it has not been addressed and given the rate of work on select2 may not be for some time. While annoying, it is not a dealbreaker and hopefully will be addressed at some point. Currently the code has a workaround. 